### PR TITLE
Update documentation to the new :kconfig: role

### DIFF
--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -13,6 +13,7 @@ NRF_BASE = Path(__file__).absolute().parents[2]
 sys.path.insert(0, str(NRF_BASE / "doc" / "_utils"))
 import utils
 
+ZEPHYR_BASE = utils.get_projdir("zephyr")
 NRFXLIB_BASE = utils.get_projdir("nrfxlib")
 
 # General configuration --------------------------------------------------------
@@ -22,6 +23,7 @@ copyright = "2019-2021, Nordic Semiconductor"
 author = "Nordic Semiconductor"
 version = release = "1.6.99"
 
+sys.path.insert(0, str(ZEPHYR_BASE / "doc" / "_extensions"))
 sys.path.insert(0, str(NRF_BASE / "doc" / "_extensions"))
 
 extensions = [
@@ -29,6 +31,7 @@ extensions = [
     "breathe",
     "sphinxcontrib.mscgen",
     "inventory_builder",
+    "zephyr.kconfig-role",
     "ncs_cache",
     "external_content",
     "doxyrunner",

--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -226,7 +226,7 @@ ALIASES                = "rst=\verbatim embed:rst" \
                          "endrststar=\endverbatim" \
                          "r=\verbatim embed:rst:leading-asterisk" \
                          "er=\endverbatim"
-ALIASES += option{1}="\verbatim embed:rst:inline :option:`\1` \endverbatim"
+ALIASES += kconfig{1}="\verbatim embed:rst:inline :kconfig:`\1` \endverbatim"
 ALIASES += "req=\xrefitem req \"Requirement\" \"Requirements\" "
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).

--- a/west.yml
+++ b/west.yml
@@ -105,7 +105,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 897294afc7d41943d68d4847855b04d7e8857173
+      revision: pull/527/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tfm


### PR DESCRIPTION
The Zephyr's Kconfig generator now uses the `:kconfig:` role, provided by the `zephyr.kconfig-role` extension. This PR updates all NCS docsets that used `:option:` role (or `@option` Doxygen alias) to reference Kconfig options. In case of nrfxlib, it also requires a manifest update, see https://github.com/nrfconnect/sdk-nrfxlib/pull/527