### PR TITLE
doc: zephyr: remove custom external_content usage

### DIFF
--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -32,7 +32,6 @@ extensions.remove("zephyr.doxyrunner")
 extensions = [
     "sphinx.ext.intersphinx",
     "ncs_cache",
-    "external_content",
     "doxyrunner",
 ] + extensions
 
@@ -61,21 +60,6 @@ intersphinx_mapping = dict()
 kconfig_mapping = utils.get_intersphinx_mapping("kconfig")
 if kconfig_mapping:
     intersphinx_mapping["kconfig"] = kconfig_mapping
-
-# Options for external_content -------------------------------------------------
-
-external_content_contents = [
-    (ZEPHYR_BASE / "doc", "[!_]*"),
-    (ZEPHYR_BASE, "boards/**/*.rst"),
-    (ZEPHYR_BASE, "boards/**/doc"),
-    (ZEPHYR_BASE, "samples/**/*.rst"),
-    (ZEPHYR_BASE, "samples/**/doc"),
-]
-external_content_keep = [
-    "reference/devicetree/bindings.rst",
-    "reference/devicetree/bindings/**/*",
-    "reference/devicetree/compatibles/**/*",
-]
 
 # Options for ncs_cache --------------------------------------------------------
 


### PR DESCRIPTION
Zephyr docs already use this extension, current overrides were added
before upstream Zephyr migrated to the external_content extension.

Note that usage of local extensions can be removed now, but will be done after docs build fine.