### PR TITLE
modules: tfm: pass ZEPHYR_BASE to TF-M build

### DIFF
--- a/modules/tfm/zephyr/CMakeLists.txt
+++ b/modules/tfm/zephyr/CMakeLists.txt
@@ -38,6 +38,10 @@ set_property(TARGET zephyr_property_target
   APPEND PROPERTY TFM_CMAKE_OPTIONS -DNRF_DIR=${ZEPHYR_NRF_MODULE_DIR}
   )
 
+set_property(TARGET zephyr_property_target
+  APPEND PROPERTY TFM_CMAKE_OPTIONS -DZEPHYR_BASE=${ZEPHYR_BASE}
+  )
+
 if (CONFIG_TFM_MINIMAL)
   set_property(TARGET zephyr_property_target
     APPEND PROPERTY TFM_CMAKE_OPTIONS


### PR DESCRIPTION
We use this variable downstream when passing our
out of tree platform to the TF-M build system.

Ref: NCSDK-10706
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>