### PR TITLE
bluetooth/gatt_dm: made BT_GATT_DM_DATA_PRINT independent from BT_DEBUG

### DIFF
--- a/subsys/bluetooth/Kconfig.discovery
+++ b/subsys/bluetooth/Kconfig.discovery
@@ -19,7 +19,6 @@ config BT_GATT_DM_MAX_ATTRS
 
 config BT_GATT_DM_DATA_PRINT
 	bool "Enable functions for printing discovery related data"
-	depends on BT_DEBUG
 	help
 	  Enable functions for printing discovery related data
 


### PR DESCRIPTION
There is no reason for having this feature dependent on a Logging subsystem as it is using printk.